### PR TITLE
Add support for ILSpy 7

### DIFF
--- a/CosturaPlugin/ContextMenuCommand.cs
+++ b/CosturaPlugin/ContextMenuCommand.cs
@@ -11,7 +11,7 @@ using Mono.Cecil.Cil;
 
 namespace CosturaPlugin
 {
-	[ExportContextMenuEntryAttribute(Header = "_Load Embedded References", Category = "CosturaPlugin", Icon = "Load.png")]
+	[ExportContextMenuEntryAttribute(Header = "_Load Embedded References", Category = "CosturaPlugin", Icon = "Images/Load.png")]
 	public class LoadEmbeddedReferences : IContextMenuEntry
 	{
 		public bool IsVisible(TextViewContext context)
@@ -29,7 +29,7 @@ namespace CosturaPlugin
 			if (context.SelectedTreeNodes == null)
 				return;
 			AssemblyTreeNode node = (AssemblyTreeNode)context.SelectedTreeNodes[0];
-			AssemblyDefinition asm = node.LoadedAssembly.GetAssemblyDefinitionOrNull();
+			AssemblyDefinition asm = AssemblyDefinition.ReadAssembly(node.LoadedAssembly.FileName);
 			ModuleDefinition module = asm.MainModule;
 			string assemblyPath = Path.GetDirectoryName(node.LoadedAssembly.FileName);
 			foreach (var resource in module.Resources) {
@@ -91,7 +91,7 @@ namespace CosturaPlugin
 
 	}
 
-	[ExportContextMenuEntryAttribute(Header = "_Remove Costura Module Initializer", Category = "CosturaPlugin", Icon = "Chop.png")]
+	[ExportContextMenuEntryAttribute(Header = "_Remove Costura Module Initializer", Category = "CosturaPlugin", Icon = "Images/Chop.png")]
 	public class DefuseCostura : IContextMenuEntry
 	{
 		public bool IsVisible(TextViewContext context)
@@ -109,7 +109,7 @@ namespace CosturaPlugin
 			if (context.SelectedTreeNodes == null)
 				return;
 			AssemblyTreeNode node = (AssemblyTreeNode)context.SelectedTreeNodes[0];
-			AssemblyDefinition asm = node.LoadedAssembly.GetAssemblyDefinitionOrNull();
+			AssemblyDefinition asm = AssemblyDefinition.ReadAssembly(node.LoadedAssembly.FileName);
 			ModuleDefinition module = asm.MainModule;
 
 			foreach (var type in module.Types) {

--- a/CosturaPlugin/CosturaPlugin.csproj
+++ b/CosturaPlugin/CosturaPlugin.csproj
@@ -2,12 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyName>Costura.Plugin</AssemblyName>
-
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-
-    <EnableDefaultItems>False</EnableDefaultItems>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -21,22 +18,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Workaround for lack of XAML support in the new project system -->
-    <LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Windows.Forms">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\System.Windows.Forms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
@@ -44,13 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="ContextMenuCommand.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Resource Include="Images/Load.png" />
-	<Resource Include="Images/Chop.png" />
+    <Resource Include="Images/Chop.png" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds support for ILSpy 7 (resolves #2).

Changes:
- updated CosturaPlugin.csproj to match the test plugin project from the ILSpy repository
- replaced calls to `GetAssemblyDefinitionOrNull`. As noted in #2 this method has been removed. A reliable alternative seems to be `AssemblyDefinition.ReadAssembly`.
